### PR TITLE
Add queue wait reasons metric gathering

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -30,6 +30,7 @@ namespace TeamCityBuildStatsScraper
                             UseDefaultCollectors = false
                         }));
                     services.AddHostedService<TeamCityBuildArtifactScraper>();
+                    services.AddHostedService<TeamCityQueueScraper>();
                 })
                 .UseConsoleLifetime()
                 .Build();

--- a/README.md
+++ b/README.md
@@ -34,4 +34,8 @@ In a rolling three-hour window, the app collects the below [gauges](https://prom
 - `build_artifact_push_time` - mean time (in milliseconds) spent pushing build artifacts from the agent
 - `build_artifact_pull_time` - mean time (in milliseconds) spent pulling build artifacts into the agent
 
+Every minute, the app collects this:
+
+- `queued_builds_with_reason` - total number of builds queued per wait reason
+
 Each gauge has a label called `buildTypeId` which matches the Build Configuration ID in TeamCity (not the numeric internal ID, but the human-readable one).

--- a/TeamCityQueueScraper.cs
+++ b/TeamCityQueueScraper.cs
@@ -84,12 +84,15 @@ namespace TeamCityBuildStatsScraper
         
         public Task StopAsync(CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            Console.WriteLine("Shutting down...");
+
+            return Task.CompletedTask;
         }
 
         public void Dispose()
         {
-            throw new NotImplementedException();
+            _host?.Dispose();
+            _timer?.Dispose();
         }
     }
 }

--- a/TeamCityQueueScraper.cs
+++ b/TeamCityQueueScraper.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.InteropServices.ComTypes;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Prometheus.Client;
+using TeamCitySharp;
+
+namespace TeamCityBuildStatsScraper
+{
+    internal class TeamCityQueueScraper: IHostedService, IDisposable
+    {
+        private readonly IHost _host;
+        private readonly IConfiguration _configuration;
+        private Timer _timer;
+
+        public TeamCityQueueScraper(IHost host, IConfiguration configuration)
+        {
+            _host = host;
+            _configuration = configuration;
+        }
+        
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            // Fire off the Scraper starting *right now* and do it again every minute
+            _timer = new Timer(ScrapeQueueStats, null, TimeSpan.Zero, TimeSpan.FromMinutes(1));
+
+            return Task.CompletedTask;
+        }
+
+        private void ScrapeQueueStats(object state)
+        {
+            var metricFactory = _host.Services.GetRequiredService<IMetricFactory>();
+            var teamCityToken = _configuration.GetValue<string>("TEAMCITY_TOKEN");
+            var teamCityUrl = _configuration.GetValue<string>("BUILD_SERVER_URL");
+            var teamCityClient = new TeamCityClient(teamCityUrl, true);
+
+            teamCityClient.ConnectWithAccessToken(teamCityToken);
+
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+            
+            var queuedBuilds = teamCityClient.BuildQueue
+                .GetFields("count,build(id,waitReason,buildTypeId,queuedDate,statistics(property,value,name))")
+                .All()
+                // exclude builds with no wait reason - these are the ones that are 'starting shortly'
+                .Where(qb => qb.WaitReason != null)
+                .ToArray();
+
+            stopwatch.Stop();
+
+            var queueStats = queuedBuilds
+                .GroupBy(qb => qb.WaitReason)
+                .Select(qb => new
+                {
+                    waitReason = qb.Key,
+                    queuedBuildCount = qb.Count()
+                })
+                .ToArray();
+
+            var waitReasonsGauge = metricFactory.CreateGauge("queued_builds_with_reason", "Count of builds in the queue for each queue reason", "waitReason");
+            
+            var consoleString = new StringBuilder();
+
+            consoleString.AppendLine($"Scrape complete at {DateTime.UtcNow.ToString(CultureInfo.InvariantCulture)}");
+            consoleString.AppendLine($"Completed scrape of TeamCity in {stopwatch.ElapsedMilliseconds} ms. Gauges generated were:");
+            consoleString.AppendLine("-------------------");
+            consoleString.AppendLine("Wait Reason | Count");
+
+            foreach (var item in queueStats)
+            {
+                waitReasonsGauge.WithLabels(item.waitReason).Set(item.queuedBuildCount);
+                consoleString.AppendLine($"{item.waitReason} | {item.queuedBuildCount}");
+            }
+
+            Console.WriteLine(consoleString.ToString());
+        }
+        
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Dispose()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds another scraper service that polls TeamCity every minute and exposes a metric for the number of queued builds along with the reason they are queued.

<img width="829" alt="Screen Shot 2021-08-24 at 10 56 30 am" src="https://user-images.githubusercontent.com/3939499/130538467-2d6e7407-cbf7-4bec-aea3-1dd68e5572dd.png">
