### PR TITLE
Add scraper to detect hanging builds

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -29,8 +29,9 @@ namespace TeamCityBuildStatsScraper
                             Port = 9090,
                             UseDefaultCollectors = false
                         }));
-                    services.AddHostedService<TeamCityBuildArtifactScraper>();
                     services.AddHostedService<TeamCityQueueScraper>();
+                    services.AddHostedService<TeamCityBuildScraper>();
+                    services.AddHostedService<TeamCityBuildArtifactScraper>();
                 })
                 .UseConsoleLifetime()
                 .Build();

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ In a rolling three-hour window, the app collects the below [gauges](https://prom
 
 Every minute, the app collects this:
 
+- `probably_hanging_builds` - number of builds that are probably hanging, per build type
 - `queued_builds_with_reason` - total number of builds queued per wait reason
 
 Each gauge has a label called `buildTypeId` which matches the Build Configuration ID in TeamCity (not the numeric internal ID, but the human-readable one).

--- a/TeamCityBuildScraper.cs
+++ b/TeamCityBuildScraper.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Prometheus.Client;
+using TeamCitySharp;
+using TeamCitySharp.Locators;
+
+namespace TeamCityBuildStatsScraper
+{
+    internal class TeamCityBuildScraper: IHostedService, IDisposable
+    {
+        private readonly IMetricFactory _metricFactory;
+        private readonly IConfiguration _configuration;
+        private Timer _timer;
+
+        public TeamCityBuildScraper(IMetricFactory metricFactory, IConfiguration configuration)
+        {
+            _metricFactory = metricFactory;
+            _configuration = configuration;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            // Fire off the Scraper starting *right now* and do it again every minute
+            _timer = new Timer(ScrapeBuildStats, null, TimeSpan.Zero, TimeSpan.FromMinutes(1));
+
+            return Task.CompletedTask;
+        }
+
+        private void ScrapeBuildStats(object state)
+        {
+            var teamCityToken = _configuration.GetValue<string>("TEAMCITY_TOKEN");
+            var teamCityUrl = _configuration.GetValue<string>("BUILD_SERVER_URL");
+            var teamCityClient = new TeamCityClient(teamCityUrl, true);
+
+            teamCityClient.ConnectWithAccessToken(teamCityToken);
+
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            var hungBuilds = teamCityClient.Builds
+                .GetFields("count,build(id,probablyHanging,buildTypeId)")
+                .ByBuildLocator(BuildLocator.WithDimensions(running: true), new List<string> { "hanging:true" })
+                .ToArray();
+
+            stopwatch.Stop();
+
+            var waitReasonsGauge = _metricFactory.CreateGauge("probably_hanging_builds", "Count of running builds that appear to be hung", "buildTypeId");
+
+            var consoleString = new StringBuilder();
+
+            consoleString.AppendLine($"Scrape complete at {DateTime.UtcNow.ToString(CultureInfo.InvariantCulture)}");
+            consoleString.AppendLine($"Completed scrape of hanging builds in {stopwatch.ElapsedMilliseconds} ms. Gauges generated were:");
+            consoleString.AppendLine("----------------------------------------------------------");
+            consoleString.AppendLine("Build Type | Count");
+
+            foreach (var build in hungBuilds.GroupBy(x => x.BuildTypeId))
+            {
+                waitReasonsGauge.WithLabels(build.Key).Set(build.Count());
+                consoleString.AppendLine($"{build.Key} | {(build.Count())}");
+            }
+
+            Console.WriteLine(consoleString.ToString());
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            Console.WriteLine("Shutting down...");
+
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            _timer?.Dispose();
+        }
+    }
+}

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "5.0.204",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
So we can replace our daily "please go check teamcity".

I added grouping by `buildTypeId`, so we could (eventually) do some analysis about "these builds seem to hang lots, what's going on".

Note: The UI doesn't show dependent builds as hanging, but the api does. So, on the "agents overview" page, we'd see one build, but this will return any builds waiting on it as well.

## Input

Agents overview shows:
![image](https://user-images.githubusercontent.com/373389/131572794-cd3c98ae-9983-4a95-8e49-d7d2cc8fdb2d.png)

https://teamcity/app/rest/builds/?locator=state:running,hanging:true&fields=count,build(probablyHanging,buildTypeId) shows:
![image](https://user-images.githubusercontent.com/373389/131572496-6af657eb-b626-414d-9298-1349e24ccbcc.png)

## Results
![image](https://user-images.githubusercontent.com/373389/131572548-9fd28a38-c39a-403d-b07b-8929f985ffbe.png)

## Sumo

We can use a query `metric=probably_hanging_builds | sum by metric` to add all of them together. We can then add an alert "alert when result is greater than 0 continuously for 30 minutes" or similar.
