### PR TITLE
Added filtering on queued builds based on concurrency limits

### DIFF
--- a/source/Program.cs
+++ b/source/Program.cs
@@ -30,9 +30,9 @@ namespace TeamCityBuildStatsScraper
                             Port = 9090,
                             UseDefaultCollectors = false
                         }));
-                    // services.AddHostedService<TeamCityQueueLengthScraper>();
-                    // services.AddHostedService<TeamCityBuildScraper>();
-                    // services.AddHostedService<TeamCityBuildArtifactScraper>();
+                    services.AddHostedService<TeamCityQueueLengthScraper>();
+                    services.AddHostedService<TeamCityBuildScraper>();
+                    services.AddHostedService<TeamCityBuildArtifactScraper>();
                     services.AddHostedService<TeamCityQueueWaitScraper>();
                 })
                 .UseConsoleLifetime()

--- a/source/Program.cs
+++ b/source/Program.cs
@@ -30,9 +30,9 @@ namespace TeamCityBuildStatsScraper
                             Port = 9090,
                             UseDefaultCollectors = false
                         }));
-                    services.AddHostedService<TeamCityQueueLengthScraper>();
-                    services.AddHostedService<TeamCityBuildScraper>();
-                    services.AddHostedService<TeamCityBuildArtifactScraper>();
+                    // services.AddHostedService<TeamCityQueueLengthScraper>();
+                    // services.AddHostedService<TeamCityBuildScraper>();
+                    // services.AddHostedService<TeamCityBuildArtifactScraper>();
                     services.AddHostedService<TeamCityQueueWaitScraper>();
                 })
                 .UseConsoleLifetime()

--- a/source/Scrapers/TeamCityQueueWaitScraper.cs
+++ b/source/Scrapers/TeamCityQueueWaitScraper.cs
@@ -158,6 +158,8 @@ namespace TeamCityBuildStatsScraper.Scrapers
                 // exclude builds just waiting on other builds
                 .Where(qb => !qb.WaitReason.Contains("Build dependencies have not been built yet"))
                 .Where(qb => !branchWaitRegex.IsMatch(qb.WaitReason))
+                // exclude builds waiting due to concurrency limits
+                .Where(qb => !qb.WaitReason.Contains("The maximum number of running builds for this configuration is reached"))
                 // exclude builds where any artifact dependency is still building, unless there are none
                 .Where(AllDependenciesComplete)
                 .ToArray();

--- a/source/Scrapers/TeamCityQueueWaitScraper.cs
+++ b/source/Scrapers/TeamCityQueueWaitScraper.cs
@@ -157,8 +157,8 @@ namespace TeamCityBuildStatsScraper.Scrapers
                 .Where(qb => qb.WaitReason != null)
                 // exclude builds just waiting on other builds
                 .Where(qb => !qb.WaitReason.Contains("Build dependencies have not been built yet"))
+                // these 2 exclude builds waiting due to concurrency limits
                 .Where(qb => !branchWaitRegex.IsMatch(qb.WaitReason))
-                // exclude builds waiting due to concurrency limits
                 .Where(qb => !qb.WaitReason.Contains("The maximum number of running builds for this configuration is reached"))
                 // exclude builds where any artifact dependency is still building, unless there are none
                 .Where(AllDependenciesComplete)

--- a/source/Scrapers/TeamCityQueueWaitScraper.cs
+++ b/source/Scrapers/TeamCityQueueWaitScraper.cs
@@ -157,9 +157,10 @@ namespace TeamCityBuildStatsScraper.Scrapers
                 .Where(qb => qb.WaitReason != null)
                 // exclude builds just waiting on other builds
                 .Where(qb => !qb.WaitReason.Contains("Build dependencies have not been built yet"))
-                // these 2 exclude builds waiting due to concurrency limits
+                // these 3 exclude builds waiting due to concurrency limits
                 .Where(qb => !branchWaitRegex.IsMatch(qb.WaitReason))
                 .Where(qb => !qb.WaitReason.Contains("The maximum number of running builds for this configuration is reached"))
+                .Where(qb => !qb.WaitReason.Contains("Build is waiting for the following resource to become available"))
                 // exclude builds where any artifact dependency is still building, unless there are none
                 .Where(AllDependenciesComplete)
                 .ToArray();


### PR DESCRIPTION
When users add build concurrency limits on projects, it causes alerting to be overly sensitive due to the builds being treated as per normal. We don't believe that this is a valid case for alerting, as we can't control this.

This PR makes the build list filter out builds with the status message `The maximum number of running builds for this configuration is reached`.