### PR TITLE
Added Sanitize method for waitReason for shared resource reason

### DIFF
--- a/source/Scrapers/TeamCityQueueLengthScraper.cs
+++ b/source/Scrapers/TeamCityQueueLengthScraper.cs
@@ -55,7 +55,7 @@ namespace TeamCityBuildStatsScraper.Scrapers
             stopwatch.Stop();
 
             var queueStats = queuedBuilds
-                .GroupBy(qb => qb.WaitReason)
+                .GroupBy(qb => Sanitize(qb.WaitReason))
                 .Select(qb => new
                 {
                     waitReason = qb.Key,
@@ -95,6 +95,13 @@ namespace TeamCityBuildStatsScraper.Scrapers
             }
 
             Console.WriteLine(consoleString.ToString());
+        }
+
+        string Sanitize(string waitReason)
+        {
+            return waitReason.StartsWith("Build is waiting for the following resource to become available")
+                ? "Build is waiting for a shared resource"
+                : waitReason;
         }
 
         public Task StopAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
When there are builds waiting on shared resources, the displayed waitReason includes the full path of every build that is locking the required resource. This PR changes this to be more readable, and indicate the actual problem (and the actual severity of it) by grouping these under the label `Build is waiting for a shared resource`.