### PR TITLE
Include wait reason in queued build list

### DIFF
--- a/source/Scrapers/TeamCityQueueWaitScraper.cs
+++ b/source/Scrapers/TeamCityQueueWaitScraper.cs
@@ -83,11 +83,11 @@ namespace TeamCityBuildStatsScraper.Scrapers
              */
 
             var metrics = metricFactory
-                .CreateSummary("queued_builds_wait_times_by_type", "How long each build type has been waiting to start", "buildTypeId");
+                .CreateSummary("queued_builds_wait_times_by_type", "How long each build type has been waiting to start", "buildTypeId", "waitReason");
 
             foreach (var queuedBuild in queueStats)
             {
-                metrics.WithLabels(queuedBuild.BuildType).Observe(queuedBuild.TimeInQueue.TotalMilliseconds);
+                metrics.WithLabels(queuedBuild.BuildType, queuedBuild.WaitReason).Observe(queuedBuild.TimeInQueue.TotalMilliseconds);
             }
 
             // In other scrapers we track previously-observed build types in order to reset their gauges. With a Summary, the Prometheus library

--- a/source/Scrapers/TeamCityQueueWaitScraper.cs
+++ b/source/Scrapers/TeamCityQueueWaitScraper.cs
@@ -103,12 +103,12 @@ namespace TeamCityBuildStatsScraper.Scrapers
             consoleString.AppendLine($"Scrape complete at {DateTime.UtcNow.ToString(CultureInfo.InvariantCulture)}");
             consoleString.AppendLine($"Completed scrape of queued build waiting time in {scrapeDuration.TotalMilliseconds} ms. Builds captured were:");
             consoleString.AppendLine("-------------------------------------------------------------------------------------------");
-            consoleString.AppendLine("Build Type | Id | Wait Duration | Now | Queued Date-Time | Latest Dependency Finish Time");
+            consoleString.AppendLine("Build Type | Id | Wait Duration | Now | Queued Date-Time | Latest Dependency Finish Time | Wait Reason");
 
             foreach (var queuedBuild in queueStats)
             {
                 consoleString.AppendLine(
-                    $"{queuedBuild.BuildType} | {queuedBuild.Id} | {queuedBuild.TimeInQueue.TotalMilliseconds} | {DateTime.UtcNow} | {queuedBuild.QueuedTime} | {queuedBuild.LastDependencyFinishTime}");
+                    $"{queuedBuild.BuildType} | {queuedBuild.Id} | {queuedBuild.TimeInQueue.TotalMilliseconds} | {DateTime.UtcNow} | {queuedBuild.QueuedTime} | {queuedBuild.LastDependencyFinishTime} | {queuedBuild.WaitReason}");
             }
 
             var currentBuildTypes = queueStats.Select(x => x.BuildType).Distinct().ToArray();
@@ -139,7 +139,8 @@ namespace TeamCityBuildStatsScraper.Scrapers
                         Id = qb.Id,
                         QueuedTime = (qb.QueuedDate), // local development you may need to offset these values; TC seems to do some magic converting TZs
                         LastDependencyFinishTime = latestQueueDate,
-                        TimeInQueue = now - latestQueueDate
+                        TimeInQueue = now - latestQueueDate,
+                        WaitReason = qb.WaitReason
                     };
                 })
                 .ToArray();
@@ -192,10 +193,11 @@ namespace TeamCityBuildStatsScraper.Scrapers
 
     class QueuedBuildStats
     {
-        public string BuildType { get; set; }
-        public string Id { get; set; }
-        public DateTime QueuedTime { get; set; }
-        public DateTime LastDependencyFinishTime { get; set; }
-        public TimeSpan TimeInQueue { get; set; }
+        public string BuildType { get; init; }
+        public string Id { get; init; }
+        public DateTime QueuedTime { get; init; }
+        public DateTime LastDependencyFinishTime { get; init; }
+        public TimeSpan TimeInQueue { get; init; }
+        public string WaitReason { get; init; }
     }
 }


### PR DESCRIPTION
So we can investigate better when we get alerts

```
Completed scrape of queued build waiting time in 9002.2292 ms. Builds captured were:
-------------------------------------------------------------------------------------------
Build Type | Id | Wait Duration | Now | Queued Date-Time | Latest Dependency Finish Time | Wait Reason
DockerAgentMaintenance | 5158407 | 54030245.862 | 11/8/2022 8:05:33 am | 10/8/2022 5:05:03 pm | 10/8/2022 5:05:03 pm | There are no idle compatible agents which can run this build
DockerAgentMaintenance | 5158430 | 54030245.862 | 11/8/2022 8:05:33 am | 10/8/2022 5:05:03 pm | 10/8/2022 5:05:03 pm | There are no idle compatible agents which can run this build
DockerAgentMaintenance | 5158364 | 54030245.862 | 11/8/2022 8:05:33 am | 10/8/2022 5:05:03 pm | 10/8/2022 5:05:03 pm | There are no idle compatible agents which can run this build
DockerAgentMaintenance | 5170581 | -32384754.138 | 11/8/2022 8:05:33 am | 11/8/2022 5:05:18 pm | 11/8/2022 5:05:18 pm | There are no idle compatible agents which can run this build
CalculateVersion | 5171538 | -35973754.138 | 11/8/2022 8:05:33 am | 11/8/2022 6:05:07 pm | 11/8/2022 6:05:07 pm | Build settings have not been finalized
```

This also includes the build type id in both the `queued_builds_wait_times_by_type` and `queued_builds_with_reason` guages, so we can see this information in metrics as well:

```
queued_builds_wait_times_by_type{buildTypeId=DockerAgentMaintenance",waitReason="There are no idle compatible agents which can run this build",quantile="0.5"} -28969124.179
queued_builds_wait_times_by_type{buildTypeId=DockerAgentMaintenance",waitReason="There are no idle compatible agents which can run this build",quantile="0.9"} -28954198.155
queued_builds_wait_times_by_type{buildTypeId=DockerAgentMaintenance",waitReason="There are no idle compatible agents which can run this build",quantile="0.99"} -28954198.155
queued_builds_wait_times_by_type_sum{buildTypeId=DockerAgentMaintenance",waitReason="There are no idle compatible agents which can run this build"} -115906258.182
queued_builds_wait_times_by_type_count{buildTypeId=DockerAgentMaintenance",waitReason="There are no idle compatible agents which can run this build"} 4
```

```
queued_builds_with_reason{buildTypeId="CreateRelease",waitReason="Build dependencies have not been built yet"} 1
queued_builds_with_reason{buildTypeId="PublishPushPackagesAndCreateRelease",waitReason="Build dependencies have not been built yet"} 14

```

