### PR TITLE
Retry forever on error

### DIFF
--- a/source/Scrapers/BackgroundService.cs
+++ b/source/Scrapers/BackgroundService.cs
@@ -23,7 +23,7 @@ public abstract class BackgroundService : IHostedService, IDisposable
 
     async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        stoppingToken.Register(() => Console.WriteLine($"{nameof(TeamCityQueueWaitScraper)} background task is starting."));
+        stoppingToken.Register(() => Console.WriteLine($"{GetType().Name} background task is starting."));
 
         while (!stoppingToken.IsCancellationRequested)
         {

--- a/source/Scrapers/BackgroundService.cs
+++ b/source/Scrapers/BackgroundService.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Polly;
+using Polly.Retry;
+
+namespace TeamCityBuildStatsScraper.Scrapers;
+
+//from https://docs.microsoft.com/en-us/dotnet/architecture/microservices/multi-container-microservice-net-applications/background-tasks-with-ihostedservice
+public abstract class BackgroundService : IHostedService, IDisposable
+{
+    Task executingTask;
+    readonly CancellationTokenSource stoppingCts = new();
+    readonly RetryPolicy retryPolicy;
+
+    protected BackgroundService()
+    {
+        retryPolicy = GetRetryPolicy();
+    }
+    
+    protected abstract void Scrape();
+
+    async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        stoppingToken.Register(() => Console.WriteLine($"{nameof(TeamCityQueueWaitScraper)} background task is starting."));
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                retryPolicy.Execute(_ => Scrape(), stoppingToken);
+                await Task.Delay(TimeSpan.FromSeconds(15), stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                Console.WriteLine($"Task cancellation detected in {nameof(TeamCityQueueWaitScraper)} background task - shutting down.");
+            }
+        }
+
+        Console.WriteLine($"{nameof(TeamCityQueueWaitScraper)} background task is stopping.");
+    }
+    
+    public virtual Task StartAsync(CancellationToken cancellationToken)
+    {
+        // Store the task we're executing
+        executingTask = ExecuteAsync(stoppingCts.Token);
+
+        // If the task is completed then return it,
+        // this will bubble cancellation and failure to the caller
+        if (executingTask.IsCompleted)
+            return executingTask;
+
+        // Otherwise it's running
+        return Task.CompletedTask;
+    }
+
+    public virtual async Task StopAsync(CancellationToken cancellationToken)
+    {
+        // Stop called without start
+        if (executingTask == null)
+            return;
+
+        try
+        {
+            // Signal cancellation to the executing method
+            stoppingCts.Cancel();
+        }
+        finally
+        {
+            // Wait until the task completes or the stop token triggers
+            await Task.WhenAny(executingTask, Task.Delay(Timeout.Infinite, cancellationToken));
+        }
+    }
+
+    public virtual void Dispose()
+    {
+        stoppingCts.Cancel();
+        GC.SuppressFinalize(this);
+    }
+    
+    static RetryPolicy GetRetryPolicy()
+    {
+        const int retryCount = 10;
+        var policy = Policy
+            .Handle<Exception>()
+            .WaitAndRetryForever(retryNumber => TimeSpan.FromSeconds(30),
+                (exception, attempt, waitTime) =>
+                    Console.Write($"Exception {exception.Message} while trying to scrape TeamCity stats. Waiting {0} before next retry. Retry attempt {1} of {2} attempts",
+                        waitTime,
+                        attempt,
+                        retryCount)
+            );
+        return policy;
+    }
+}

--- a/source/Scrapers/TeamCityBuildArtifactScraper.cs
+++ b/source/Scrapers/TeamCityBuildArtifactScraper.cs
@@ -13,11 +13,10 @@ using TeamCitySharp.Locators;
 
 namespace TeamCityBuildStatsScraper.Scrapers
 {
-    class TeamCityBuildArtifactScraper : IHostedService, IDisposable
+    class TeamCityBuildArtifactScraper : BackgroundService
     {
         readonly IMetricFactory metricFactory;
         readonly IConfiguration configuration;
-        Timer timer;
 
         public TeamCityBuildArtifactScraper(IMetricFactory metricFactory, IConfiguration configuration)
         {
@@ -25,15 +24,7 @@ namespace TeamCityBuildStatsScraper.Scrapers
             this.configuration = configuration;
         }
 
-        public Task StartAsync(CancellationToken cancellationToken)
-        {
-            // Fire off the Scraper starting *right now* and do it again every five minutes
-            timer = new Timer(ScrapeArtifactStats, null, TimeSpan.Zero, TimeSpan.FromMinutes(5));
-
-            return Task.CompletedTask;
-        }
-
-        void ScrapeArtifactStats(object state)
+        protected override void Scrape()
         {
             var teamCityToken = configuration.GetValue<string>("TEAMCITY_TOKEN");
             var teamCityUrl = configuration.GetValue<string>("BUILD_SERVER_URL");
@@ -104,18 +95,6 @@ namespace TeamCityBuildStatsScraper.Scrapers
             }
 
             Console.WriteLine(consoleString.ToString());
-        }
-
-        public Task StopAsync(CancellationToken cancellationToken)
-        {
-            Console.WriteLine("Shutting down...");
-
-            return Task.CompletedTask;
-        }
-
-        public void Dispose()
-        {
-            timer?.Dispose();
         }
     }
 }

--- a/source/Scrapers/TeamCityBuildScraper.cs
+++ b/source/Scrapers/TeamCityBuildScraper.cs
@@ -14,12 +14,11 @@ using TeamCitySharp.Locators;
 
 namespace TeamCityBuildStatsScraper.Scrapers
 {
-    class TeamCityBuildScraper : IHostedService, IDisposable
+    class TeamCityBuildScraper : BackgroundService
     {
         readonly IMetricFactory metricFactory;
         readonly IConfiguration configuration;
         readonly HashSet<string> seenBuildTypes = new();
-        Timer timer;
 
         public TeamCityBuildScraper(IMetricFactory metricFactory, IConfiguration configuration)
         {
@@ -27,15 +26,7 @@ namespace TeamCityBuildStatsScraper.Scrapers
             this.configuration = configuration;
         }
 
-        public Task StartAsync(CancellationToken cancellationToken)
-        {
-            // Fire off the Scraper starting *right now* and do it again every minute
-            timer = new Timer(ScrapeBuildStats, null, TimeSpan.Zero, TimeSpan.FromMinutes(1));
-
-            return Task.CompletedTask;
-        }
-
-        void ScrapeBuildStats(object state)
+        protected override void Scrape()
         {
             var teamCityToken = configuration.GetValue<string>("TEAMCITY_TOKEN");
             var teamCityUrl = configuration.GetValue<string>("BUILD_SERVER_URL");
@@ -80,18 +71,6 @@ namespace TeamCityBuildStatsScraper.Scrapers
             }
 
             Console.WriteLine(consoleString.ToString());
-        }
-
-        public Task StopAsync(CancellationToken cancellationToken)
-        {
-            Console.WriteLine("Shutting down...");
-
-            return Task.CompletedTask;
-        }
-
-        public void Dispose()
-        {
-            timer?.Dispose();
         }
     }
 }

--- a/source/TeamCityBuildStatsScraper.csproj
+++ b/source/TeamCityBuildStatsScraper.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Polly" Version="7.2.3" />
         <PackageReference Include="Prometheus.Client" Version="4.5.3" />
         <PackageReference Include="Prometheus.Client.DependencyInjection" Version="1.1.0" />
         <PackageReference Include="Prometheus.Client.MetricServer" Version="4.4.0" />


### PR DESCRIPTION
We get "container restarted" alerts every time we do maintenance on TeamCity, which is a bit annoying.

This was because there was no error handling around this, and that just crashed the process (note - this is a description, not a judgement!).

This PR changes it so that:
* there's a common base class to all the scrapers, to abstract away the `IHostedService` and timer code
* adds Polly to handle retries on errors
* use a "wait 15 seconds until the next scrape" rather than an "every 15 seconds do.." to prevent overlapping runs
* pass around a cancellation token, so we can shutdown cleanly
