### PR TITLE
Removed composite builds and added buildId

### DIFF
--- a/source/Scrapers/TeamCityBuildScraper.cs
+++ b/source/Scrapers/TeamCityBuildScraper.cs
@@ -32,8 +32,8 @@ namespace TeamCityBuildStatsScraper.Scrapers
             teamCityClient.ConnectWithAccessToken(teamCityToken);
 
             var hungBuilds = teamCityClient.Builds
-                .GetFields("count,build(id,probablyHanging,buildTypeId)")
-                .ByBuildLocator(BuildLocator.WithDimensions(running: true), new List<string> { "hanging:true" })
+                .GetFields("count,build(id,probablyHanging,buildTypeId,composite)")
+                .ByBuildLocator(BuildLocator.WithDimensions(running: true), new List<string> { "hanging:true", "composite:false" })
                 .ToArray();
 
             var gauge = metricFactory.CreateGauge("probably_hanging_builds", "Count of running builds that appear to be hung", "buildTypeId");

--- a/source/Scrapers/TeamCityBuildScraper.cs
+++ b/source/Scrapers/TeamCityBuildScraper.cs
@@ -40,7 +40,7 @@ namespace TeamCityBuildStatsScraper.Scrapers
 
             foreach (var build in hungBuilds)
             {
-                gauge.WithLabels(new []{build.BuildTypeId, build.Id}).Set(1);
+                gauge.WithLabels(build.BuildTypeId, build.Id).Set(1);
                 Logger.Debug("Build Type {BuildTypeId}, build ID {BuildId} has hung", build.BuildTypeId, build.Id);
             }
 
@@ -51,7 +51,7 @@ namespace TeamCityBuildStatsScraper.Scrapers
             foreach (var (buildType, buildId) in absentBuildTypes)
             {
                 // if not present, reset the gauge to zero
-                gauge.WithLabels(new []{buildType, buildId}).Reset();
+                gauge.WithLabels(buildType, buildId).Reset();
                 Logger.Debug("Build Type {BuildTypeId}, build ID {Id} no longer hung", buildType, buildId);
             }
         }

--- a/source/Scrapers/TeamCityBuildScraper.cs
+++ b/source/Scrapers/TeamCityBuildScraper.cs
@@ -46,9 +46,9 @@ namespace TeamCityBuildStatsScraper.Scrapers
 
             var currentBuilds = hungBuilds.Select(x => (x.BuildTypeId, x.Id)).ToArray();
             seenBuilds.UnionWith(currentBuilds);
-            var absentBuildTypes = seenBuilds.Except(currentBuilds);
+            var absentBuilds = seenBuilds.Except(currentBuilds);
 
-            foreach (var (buildType, buildId) in absentBuildTypes)
+            foreach (var (buildType, buildId) in absentBuilds)
             {
                 // if not present, reset the gauge to zero
                 gauge.WithLabels(buildType, buildId).Reset();

--- a/source/Scrapers/TeamCityBuildScraper.cs
+++ b/source/Scrapers/TeamCityBuildScraper.cs
@@ -32,7 +32,7 @@ namespace TeamCityBuildStatsScraper.Scrapers
             teamCityClient.ConnectWithAccessToken(teamCityToken);
 
             var hungBuilds = teamCityClient.Builds
-                .GetFields("count,build(id,probablyHanging,buildTypeId,composite)")
+                .GetFields("count,build(id,buildTypeId)")
                 .ByBuildLocator(BuildLocator.WithDimensions(running: true), new List<string> { "hanging:true", "composite:false" })
                 .ToArray();
 

--- a/source/Scrapers/TeamCityBuildScraper.cs
+++ b/source/Scrapers/TeamCityBuildScraper.cs
@@ -14,7 +14,7 @@ namespace TeamCityBuildStatsScraper.Scrapers
     {
         readonly IMetricFactory metricFactory;
         readonly IConfiguration configuration;
-        readonly HashSet<string> seenBuildTypes = new();
+        readonly HashSet<(string, string)> seenBuilds = new();
 
         public TeamCityBuildScraper(IMetricFactory metricFactory, IConfiguration configuration, ILogger logger)
             : base(logger.ForContext("Scraper", nameof(TeamCityBuildScraper)))
@@ -36,23 +36,23 @@ namespace TeamCityBuildStatsScraper.Scrapers
                 .ByBuildLocator(BuildLocator.WithDimensions(running: true), new List<string> { "hanging:true", "composite:false" })
                 .ToArray();
 
-            var gauge = metricFactory.CreateGauge("probably_hanging_builds", "Count of running builds that appear to be hung", "buildTypeId");
+            var gauge = metricFactory.CreateGauge("probably_hanging_builds", "Running builds that appear to be hung", labelNames: new []{"buildTypeId", "buildId"});
 
-            foreach (var build in hungBuilds.GroupBy(x => x.BuildTypeId))
+            foreach (var build in hungBuilds)
             {
-                gauge.WithLabels(build.Key).Set(build.Count());
-                Logger.Debug("Build Type {BuildTypeId}, Count {Count}", build.Key, build.Count());
+                gauge.WithLabels(new []{build.BuildTypeId, build.Id}).Set(1);
+                Logger.Debug("Build Type {BuildTypeId}, build ID {BuildId} has hung", build.BuildTypeId, build.Id);
             }
 
-            var currentBuildTypes = hungBuilds.Select(x => x.BuildTypeId).Distinct().ToArray();
-            seenBuildTypes.UnionWith(currentBuildTypes);
-            var absentBuildTypes = seenBuildTypes.Except(currentBuildTypes);
+            var currentBuilds = hungBuilds.Select(x => (x.BuildTypeId, x.Id)).ToArray();
+            seenBuilds.UnionWith(currentBuilds);
+            var absentBuildTypes = seenBuilds.Except(currentBuilds);
 
-            foreach (var item in absentBuildTypes)
+            foreach (var (buildType, buildId) in absentBuildTypes)
             {
                 // if not present, reset the gauge to zero
-                gauge.WithLabels(item).Reset();
-                Logger.Debug("Build Type {BuildTypeId}, Count {Count}", item, 0);
+                gauge.WithLabels(new []{buildType, buildId}).Reset();
+                Logger.Debug("Build Type {BuildTypeId}, build ID {Id} no longer hung", buildType, buildId);
             }
         }
     }


### PR DESCRIPTION
**Background:** When looking at the probably_hanging_builds, we've found that composite builds have also been adding to the count of total builds hanging, even though the build that is hanging is already reported under its build type. While looking at this, it was deemed a "good" idea to also expose the `buildId` as its own dimension for use in alerting to specific builds that have hung.

**What this PR does:** I have changed the `ByBuildLocator` for `HungBuilds` to now filter with the `composite:false` buildLocator dimension. This prevents composite builds from appearing in the metrics at all. I have also added a new dimension to the gauge and changed all code used to reset the gauge to `0` to allow for the usage of this new dimension.