### PR TITLE
Add stats for muted tests for Octopus Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Optionally, you can also set
 
 ## Metrics collected
 
-### Build Artifact Movements
+Every 15 minutes, the app collects:
+
+- `muted_tests` - number of muted tests per build type, _currently filtered only to the Octopus Server project_.
 
 In a rolling three-hour window, the app collects the below [gauges](https://prometheus.io/docs/concepts/metric_types/#gauge) every five minutes for each build type that ran at least once in the window.
 
@@ -39,7 +41,7 @@ In a rolling three-hour window, the app collects the below [gauges](https://prom
 - `build_artifact_push_time` - mean time (in milliseconds) spent pushing build artifacts from the agent
 - `build_artifact_pull_time` - mean time (in milliseconds) spent pulling build artifacts into the agent
 
-Every minute, the app collects this:
+Every minute, the app collects:
 
 - `probably_hanging_builds` - number of builds that are probably hanging, per build type
 - `queued_builds_with_reason` - total number of builds queued per wait reason

--- a/source/Program.cs
+++ b/source/Program.cs
@@ -70,6 +70,7 @@ namespace TeamCityBuildStatsScraper
                         services.AddHostedService<TeamCityBuildScraper>();
                         services.AddHostedService<TeamCityBuildArtifactScraper>();
                         services.AddHostedService<TeamCityQueueWaitScraper>();
+                        services.AddHostedService<TeamCityMutedTestsScraper>();
                     })
                     .UseConsoleLifetime()
                     .Build();

--- a/source/Scrapers/BackgroundService.cs
+++ b/source/Scrapers/BackgroundService.cs
@@ -43,7 +43,7 @@ public abstract class BackgroundService : IHostedService, IDisposable
                     stopwatch.Stop();
                     Logger.Information("Scrape complete at {CompletionTime}, taking {Duration} ms", DateTime.UtcNow.ToString(CultureInfo.InvariantCulture),  stopwatch.ElapsedMilliseconds);
                 }, stoppingToken);
-                await Task.Delay(TimeSpan.FromSeconds(15), stoppingToken);
+                await Task.Delay(DelayBetweenScrapes, stoppingToken);
             }
             catch (OperationCanceledException)
             {
@@ -53,7 +53,9 @@ public abstract class BackgroundService : IHostedService, IDisposable
 
         Logger.Information("{TaskName} background task is stopping", GetType().Name);
     }
-    
+
+    protected abstract TimeSpan DelayBetweenScrapes { get; }
+
     public virtual Task StartAsync(CancellationToken cancellationToken)
     {
         // Store the task we're executing

--- a/source/Scrapers/TeamCityBuildArtifactScraper.cs
+++ b/source/Scrapers/TeamCityBuildArtifactScraper.cs
@@ -20,6 +20,8 @@ namespace TeamCityBuildStatsScraper.Scrapers
             this.configuration = configuration;
         }
 
+        protected override TimeSpan DelayBetweenScrapes => TimeSpan.FromMinutes(5);
+
         protected override void Scrape()
         {
             var teamCityToken = configuration.GetValue<string>("TEAMCITY_TOKEN");
@@ -84,5 +86,6 @@ namespace TeamCityBuildStatsScraper.Scrapers
                     item.meanArtifactPullTime);
             }
         }
+
     }
 }

--- a/source/Scrapers/TeamCityBuildScraper.cs
+++ b/source/Scrapers/TeamCityBuildScraper.cs
@@ -22,6 +22,7 @@ namespace TeamCityBuildStatsScraper.Scrapers
             this.metricFactory = metricFactory;
             this.configuration = configuration;
         }
+        protected override TimeSpan DelayBetweenScrapes => TimeSpan.FromMinutes(1);
 
         protected override void Scrape()
         {

--- a/source/Scrapers/TeamCityMutedTestsScraper.cs
+++ b/source/Scrapers/TeamCityMutedTestsScraper.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using Prometheus.Client;
+using Serilog;
+using TeamCitySharp;
+using TeamCitySharp.Connection;
+using TeamCitySharp.DomainEntities;
+using TeamCitySharp.Locators;
+
+namespace TeamCityBuildStatsScraper.Scrapers;
+
+class TeamCityMutedTestsScraper : BackgroundService
+{
+    readonly IMetricFactory metricFactory;
+    readonly IConfiguration configuration;
+
+    public TeamCityMutedTestsScraper(IMetricFactory metricFactory, IConfiguration configuration, ILogger logger)
+        : base(logger.ForContext("Scraper", nameof(TeamCityMutedTestsScraper)))
+    {
+        this.metricFactory = metricFactory;
+        this.configuration = configuration;
+    }
+    protected override TimeSpan DelayBetweenScrapes => TimeSpan.FromMinutes(15);
+
+    protected override void Scrape()
+    {
+        var teamCityToken = configuration.GetValue<string>("TEAMCITY_TOKEN");
+        var teamCityUrl = configuration.GetValue<string>("BUILD_SERVER_URL");
+        var teamCityClient = new TeamCityClient(teamCityUrl, true);
+
+        teamCityClient.ConnectWithAccessToken(teamCityToken);
+        
+        //https://build.octopushq.com/app/rest/tests?locator=currentlyMuted:true,affectedProject:OctopusDeploy_OctopusServer&fields=count
+
+        //Unfortunately, we dont seem to be able to use the client for this call,
+        //so for now, I'm reaching deep into it's guts to get the field I need. Ick.
+        //We should raise a PR (though there hasn't been a release for nearly 12 months)
+        var callerField = typeof(TeamCityClient).GetField("m_caller", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var caller = (ITeamCityCaller)callerField.GetValue(teamCityClient) ?? throw new ApplicationException("Unable to get m_caller field");
+
+        var hungBuilds = caller.Get<TestOccurrences>("/tests?locator=currentlyMuted:true,affectedProject:OctopusDeploy_OctopusServer&fields=count");
+        
+        metricFactory
+            .CreateGauge("muted_tests", "Count of muted tests", "buildTypeId")
+            .WithLabels("OctopusDeploy_OctopusServer")
+            .Set(hungBuilds.Count);
+        
+        Logger.Debug("Project {BuildTypeId} has {Count} muted tests", "OctopusDeploy_OctopusServer", hungBuilds.Count);
+    }
+}

--- a/source/Scrapers/TeamCityQueueLengthScraper.cs
+++ b/source/Scrapers/TeamCityQueueLengthScraper.cs
@@ -22,6 +22,7 @@ namespace TeamCityBuildStatsScraper.Scrapers
             this.metricFactory = metricFactory;
             this.configuration = configuration;
         }
+        protected override TimeSpan DelayBetweenScrapes => TimeSpan.FromSeconds(15);
 
         protected override void Scrape()
         {

--- a/source/Scrapers/TeamCityQueueWaitScraper.cs
+++ b/source/Scrapers/TeamCityQueueWaitScraper.cs
@@ -22,6 +22,7 @@ namespace TeamCityBuildStatsScraper.Scrapers
             this.metricFactory = metricFactory;
             this.configuration = configuration;
         }
+        protected override TimeSpan DelayBetweenScrapes => TimeSpan.FromSeconds(15);
 
         protected override void Scrape()
         {


### PR DESCRIPTION
We want to be able to track muted tests over time. Prometheus and sumo are a good fit for this.

![image](https://user-images.githubusercontent.com/373389/225191270-232fd400-b65b-4d4b-befb-0251026e3c95.png)

[sc-42679]