### PR TITLE
Fix retry message

### DIFF
--- a/source/Scrapers/BackgroundService.cs
+++ b/source/Scrapers/BackgroundService.cs
@@ -20,7 +20,7 @@ public abstract class BackgroundService : IHostedService, IDisposable
 
     protected BackgroundService(ILogger logger)
     {
-        this.Logger = logger;
+        Logger = logger;
         retryPolicy = GetRetryPolicy();
     }
     
@@ -96,15 +96,15 @@ public abstract class BackgroundService : IHostedService, IDisposable
     
     static RetryPolicy GetRetryPolicy()
     {
-        const int retryCount = 10;
         var policy = Policy
             .Handle<Exception>()
-            .WaitAndRetryForever(retryNumber => TimeSpan.FromSeconds(30),
+            .WaitAndRetryForever(_ => TimeSpan.FromSeconds(30),
                 (exception, attempt, waitTime) =>
-                    Console.Write($"Exception {exception.Message} while trying to scrape TeamCity stats. Waiting {0} before next retry. Retry attempt {1} of {2} attempts",
+                    Log.Error(exception,
+                        "Exception {Exception} while trying to scrape TeamCity stats. Waiting {WaitTime} before next retry. Retry attempt {Attempt}",
+                        exception.Message,
                         waitTime,
-                        attempt,
-                        retryCount)
+                        attempt)
             );
         return policy;
     }


### PR DESCRIPTION
While investigating an issue where the TeamCity queue wait scraper stopped working we thought that there was no retry logic on the code. Upon further investigation I noticed that there is a retry logic.

I also noticed that the log message on retries had an issue where some values were not being replaced correctly. This PR fixes the issue with the log message on retries.

[Sumo](https://octopus.de.sumologic.com/ui/#/search/create?id=rOLrt9INlTOJkxxuAwukIPC4ujuiEPz1AkwOxfZM)

# Before
![image](https://github.com/OctopusDeploy/TeamCityBuildStatsScraper/assets/3007213/35581f96-f63e-4aeb-b204-717746b90155)

[sc-53768]