### PR TITLE
Make the scraper method async

### DIFF
--- a/source/Scrapers/TeamCityBuildArtifactScraper.cs
+++ b/source/Scrapers/TeamCityBuildArtifactScraper.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Prometheus.Client;
 using Serilog;
@@ -22,8 +24,10 @@ namespace TeamCityBuildStatsScraper.Scrapers
 
         protected override TimeSpan DelayBetweenScrapes => TimeSpan.FromMinutes(5);
 
-        protected override void Scrape()
+        protected override async Task Scrape(CancellationToken stoppingToken)
         {
+            await Task.CompletedTask;
+            
             var teamCityToken = configuration.GetValue<string>("TEAMCITY_TOKEN");
             var teamCityUrl = configuration.GetValue<string>("BUILD_SERVER_URL");
             var teamCityClient = new TeamCityClient(teamCityUrl, true);

--- a/source/Scrapers/TeamCityBuildScraper.cs
+++ b/source/Scrapers/TeamCityBuildScraper.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Prometheus.Client;
 using Serilog;
@@ -24,8 +26,10 @@ namespace TeamCityBuildStatsScraper.Scrapers
         }
         protected override TimeSpan DelayBetweenScrapes => TimeSpan.FromMinutes(1);
 
-        protected override void Scrape()
+        protected override async Task Scrape(CancellationToken stoppingToken)
         {
+            await Task.CompletedTask;
+
             var teamCityToken = configuration.GetValue<string>("TEAMCITY_TOKEN");
             var teamCityUrl = configuration.GetValue<string>("BUILD_SERVER_URL");
             var teamCityClient = new TeamCityClient(teamCityUrl, true);

--- a/source/Scrapers/TeamCityMutedTestsScraper.cs
+++ b/source/Scrapers/TeamCityMutedTestsScraper.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Prometheus.Client;
 using Serilog;
@@ -25,8 +27,10 @@ class TeamCityMutedTestsScraper : BackgroundService
     }
     protected override TimeSpan DelayBetweenScrapes => TimeSpan.FromMinutes(15);
 
-    protected override void Scrape()
+    protected override async Task Scrape(CancellationToken stoppingToken)
     {
+        await Task.CompletedTask;
+
         var teamCityToken = configuration.GetValue<string>("TEAMCITY_TOKEN");
         var teamCityUrl = configuration.GetValue<string>("BUILD_SERVER_URL");
         var teamCityClient = new TeamCityClient(teamCityUrl, true);

--- a/source/Scrapers/TeamCityQueueLengthScraper.cs
+++ b/source/Scrapers/TeamCityQueueLengthScraper.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Prometheus.Client;
 using Serilog;
@@ -24,8 +26,10 @@ namespace TeamCityBuildStatsScraper.Scrapers
         }
         protected override TimeSpan DelayBetweenScrapes => TimeSpan.FromSeconds(15);
 
-        protected override void Scrape()
+        protected override async Task Scrape(CancellationToken stoppingToken)
         {
+            await Task.CompletedTask;
+
             var teamCityToken = configuration.GetValue<string>("TEAMCITY_TOKEN");
             var teamCityUrl = configuration.GetValue<string>("BUILD_SERVER_URL");
             var teamCityClient = new TeamCityClient(teamCityUrl, true);

--- a/source/Scrapers/TeamCityQueueWaitScraper.cs
+++ b/source/Scrapers/TeamCityQueueWaitScraper.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Prometheus.Client;
 using Serilog;
@@ -24,8 +26,10 @@ namespace TeamCityBuildStatsScraper.Scrapers
         }
         protected override TimeSpan DelayBetweenScrapes => TimeSpan.FromSeconds(15);
 
-        protected override void Scrape()
+        protected override async Task Scrape(CancellationToken stoppingToken)
         {
+            await Task.CompletedTask;
+
             var teamCityToken = configuration.GetValue<string>("TEAMCITY_TOKEN");
             var teamCityUrl = configuration.GetValue<string>("BUILD_SERVER_URL");
             var teamCityClient = new TeamCityClient(teamCityUrl, true);


### PR DESCRIPTION
So where possible, we can call async things, and pass through the cancellation token.

This was part of another PR - pulled out to make the other one smaller.