### PR TITLE
Emit stats for the teamcity file share

### DIFF
--- a/source/Program.cs
+++ b/source/Program.cs
@@ -71,6 +71,7 @@ namespace TeamCityBuildStatsScraper
                         services.AddHostedService<TeamCityBuildArtifactScraper>();
                         services.AddHostedService<TeamCityQueueWaitScraper>();
                         services.AddHostedService<TeamCityMutedTestsScraper>();
+                        services.AddHostedService<TeamCityDiskSpaceScraper>();
                     })
                     .UseConsoleLifetime()
                     .Build();

--- a/source/Scrapers/TeamCityDiskSpaceScraper.cs
+++ b/source/Scrapers/TeamCityDiskSpaceScraper.cs
@@ -6,8 +6,6 @@ using Azure.Identity;
 using Azure.ResourceManager;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Storage;
-using Azure.Storage;
-using Azure.Storage.Files.Shares;
 using Microsoft.Extensions.Configuration;
 using Prometheus.Client;
 using Serilog;
@@ -59,7 +57,6 @@ namespace TeamCityBuildStatsScraper.Scrapers
 
             try
             {
-                
                 var resourceGroupName = configuration.GetValue<string>("AZURE_FILE_SHARE_RESOURCE_GROUP_NAME");
                 var storageAccountName = configuration.GetValue<string>("AZURE_FILE_SHARE_STORAGE_ACCOUNT_NAME");
                 var subscriptionId = configuration.GetValue<string>("AZURE_FILE_SHARE_SUBSCRIPTION_ID");

--- a/source/Scrapers/TeamCityDiskSpaceScraper.cs
+++ b/source/Scrapers/TeamCityDiskSpaceScraper.cs
@@ -1,0 +1,90 @@
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Identity;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Resources;
+using Azure.ResourceManager.Storage;
+using Azure.Storage;
+using Azure.Storage.Files.Shares;
+using Microsoft.Extensions.Configuration;
+using Prometheus.Client;
+using Serilog;
+
+namespace TeamCityBuildStatsScraper.Scrapers
+{
+    record StorageStatistics(long TotalCapacity, long UsedCapacity)
+    {
+        public long AvailableCapacity => TotalCapacity - UsedCapacity;
+    }
+
+    class TeamCityDiskSpaceScraper : BackgroundService
+    {
+        readonly IMetricFactory metricFactory;
+        readonly IConfiguration configuration;
+        readonly ILogger logger;
+
+        public TeamCityDiskSpaceScraper(IMetricFactory metricFactory, IConfiguration configuration, ILogger logger)
+            : base(logger.ForContext("Scraper", nameof(TeamCityDiskSpaceScraper)))
+        {
+            this.metricFactory = metricFactory;
+            this.configuration = configuration;
+            this.logger = logger;
+        }
+
+        protected override TimeSpan DelayBetweenScrapes => TimeSpan.FromMinutes(5);
+
+        protected override async Task Scrape(CancellationToken cancellationToken)
+        {
+            var stats = await RetrieveFileStorageMetrics(cancellationToken);
+
+            var totalCapacityGauge = metricFactory.CreateGauge("build_storage_total_capacity", "Total capacity of the file share");
+            var usedCapacityGauge = metricFactory.CreateGauge("build_storage_used_capacity", "Used capacity of the file share");
+            var availableCapacityGauge = metricFactory.CreateGauge("build_storage_available_capacity", "Available capacity on the file share");
+
+            totalCapacityGauge.Set(stats?.TotalCapacity ?? 0);
+            usedCapacityGauge.Set(stats?.UsedCapacity ?? 0);
+            availableCapacityGauge.Set(stats?.AvailableCapacity ?? 0);
+            
+            Logger.Debug("TeamCity Disk Space - Total Capacity {TotalCapacity}, Used Capacity {UsedCapacity}, Available Capacity {AvailableCapacity}",
+                stats?.TotalCapacity,
+                stats?.UsedCapacity,
+                stats?.AvailableCapacity);
+        }
+
+        async Task<StorageStatistics?> RetrieveFileStorageMetrics(CancellationToken cancellationToken)
+        {
+            logger.Verbose("Retrieving Azure file storage metrics");
+
+            try
+            {
+                
+                var resourceGroupName = configuration.GetValue<string>("AZURE_FILE_SHARE_RESOURCE_GROUP_NAME");
+                var storageAccountName = configuration.GetValue<string>("AZURE_FILE_SHARE_STORAGE_ACCOUNT_NAME");
+                var subscriptionId = configuration.GetValue<string>("AZURE_FILE_SHARE_SUBSCRIPTION_ID");
+                var shareName = configuration.GetValue<string>("AZURE_FILE_SHARE_STORAGE_SHARE_NAME");
+
+                var client = new ArmClient(new DefaultAzureCredential());
+                var subscription = await client.GetSubscriptions().GetAsync(subscriptionId, cancellationToken);
+                var resourceGroups = subscription.Value.GetResourceGroups();
+                ResourceGroupResource resourceGroup = await resourceGroups.GetAsync(resourceGroupName, cancellationToken);
+                StorageAccountResource storageAccount = await resourceGroup.GetStorageAccountAsync(storageAccountName, cancellationToken: cancellationToken);
+
+                var fileService = storageAccount.GetFileService();
+                FileShareResource fileShare = await fileService.GetFileShareAsync(shareName, expand:"stats", cancellationToken: cancellationToken);
+                var shareProperties = fileShare.Data;
+                var totalCapacityInBytes = shareProperties.ShareQuota.GetValueOrDefault() * 1024L * 1024L * 1024L;
+                var shareUsageInBytes = shareProperties.ShareUsageBytes.GetValueOrDefault();
+
+                return new StorageStatistics(totalCapacityInBytes, shareUsageInBytes);
+            }
+            catch (Exception ex)
+            {
+                logger.Warning(ex, "Failed to get Azure file storage metrics");
+            }
+            return null;
+        }
+    }
+
+}

--- a/source/TeamCityBuildStatsScraper.csproj
+++ b/source/TeamCityBuildStatsScraper.csproj
@@ -7,6 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Azure.Identity" Version="1.10.4" />
+        <PackageReference Include="Azure.ResourceManager.Storage" Version="1.2.0" />
         <PackageReference Include="Polly" Version="8.3.0" />
         <PackageReference Include="Prometheus.Client" Version="5.2.0" />
         <PackageReference Include="Prometheus.Client.DependencyInjection" Version="1.3.0" />


### PR DESCRIPTION
We want to be able to track and alert on teamcity storage account exhaustion.

But, we cant get it out from azure via the standard metrics pipeline (via sumo), as it's not available :(

This PR adds a few new metrics:
* `build_storage_total_capacity`
* `build_storage_used_capacity`
* `build_storage_available_capacity`

It _should_ be able to use managed identity to get these values, and needs these env vars to work:
* `AZURE_FILE_SHARE_RESOURCE_GROUP_NAME`
* `AZURE_FILE_SHARE_STORAGE_ACCOUNT_NAME`
* `AZURE_FILE_SHARE_SUBSCRIPTION_ID`
* `AZURE_FILE_SHARE_STORAGE_SHARE_NAME`