### PR TITLE
Allow TeamCity Client to use non SSL Connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@ This app scrapes a TeamCity instance for some aggregated statistics and exposes 
 
 ## Configuration
 
-Two environment variables need to be set:
+The following environment variables need to be set:
 
 - `BUILD_SERVER_URL` - The URL (or IP address) of your TeamCity instance, without `http(s)://` or trailing `/` - e.g. `buildserver.example.com` and not `https://buildserver.example.com/`
 - `TEAMCITY_TOKEN` - An [authentication token](https://www.jetbrains.com/help/teamcity/managing-your-user-account.html#Managing+Access+Tokens) for your TeamCity instance, with enough access to read build information.
+- `USE_SSL` - Whether to use SSL for connecting to TeamCity.
 
 Optionally, you can also set
 
 - `SEQ_URL` - The URL (with http/https prefix) to a seq server to log messages to
-- `SEQ_API_KEY` - If your seq server requires an api key, you can specify it here. This also allows you to modify the logging level from seq. 
+- `SEQ_API_KEY` - If your seq server requires an api key, you can specify it here. This also allows you to modify the logging level from seq.
 
 ## How to run
 

--- a/source/Scrapers/TeamCityBuildArtifactScraper.cs
+++ b/source/Scrapers/TeamCityBuildArtifactScraper.cs
@@ -30,7 +30,7 @@ namespace TeamCityBuildStatsScraper.Scrapers
 
             var teamCityToken = configuration.GetValue<string>("TEAMCITY_TOKEN");
             var teamCityUrl = configuration.GetValue<string>("BUILD_SERVER_URL");
-            bool useSSL = configuration.GetValue<bool>("USE_SSL");
+            var useSSL = configuration.GetValue<bool>("USE_SSL");
             var teamCityClient = new TeamCityClient(teamCityUrl, useSSL);
 
             teamCityClient.ConnectWithAccessToken(teamCityToken);

--- a/source/Scrapers/TeamCityBuildArtifactScraper.cs
+++ b/source/Scrapers/TeamCityBuildArtifactScraper.cs
@@ -30,7 +30,7 @@ namespace TeamCityBuildStatsScraper.Scrapers
 
             var teamCityToken = configuration.GetValue<string>("TEAMCITY_TOKEN");
             var teamCityUrl = configuration.GetValue<string>("BUILD_SERVER_URL");
-            var useSSL = configuration.GetValue<bool>("USE_SSL");
+            bool useSSL = configuration.GetValue<bool>("USE_SSL");
             var teamCityClient = new TeamCityClient(teamCityUrl, useSSL);
 
             teamCityClient.ConnectWithAccessToken(teamCityToken);

--- a/source/Scrapers/TeamCityBuildArtifactScraper.cs
+++ b/source/Scrapers/TeamCityBuildArtifactScraper.cs
@@ -27,10 +27,11 @@ namespace TeamCityBuildStatsScraper.Scrapers
         protected override async Task Scrape(CancellationToken stoppingToken)
         {
             await Task.CompletedTask;
-            
+
             var teamCityToken = configuration.GetValue<string>("TEAMCITY_TOKEN");
             var teamCityUrl = configuration.GetValue<string>("BUILD_SERVER_URL");
-            var teamCityClient = new TeamCityClient(teamCityUrl, true);
+            var useSSL = configuration.GetValue<bool>("USE_SSL");
+            var teamCityClient = new TeamCityClient(teamCityUrl, useSSL);
 
             teamCityClient.ConnectWithAccessToken(teamCityToken);
 

--- a/source/Scrapers/TeamCityBuildScraper.cs
+++ b/source/Scrapers/TeamCityBuildScraper.cs
@@ -32,7 +32,7 @@ namespace TeamCityBuildStatsScraper.Scrapers
 
             var teamCityToken = configuration.GetValue<string>("TEAMCITY_TOKEN");
             var teamCityUrl = configuration.GetValue<string>("BUILD_SERVER_URL");
-            var useSSL = configuration.GetValue<bool>("USE_SSL");
+            bool useSSL = configuration.GetValue<bool>("USE_SSL");
             var teamCityClient = new TeamCityClient(teamCityUrl, useSSL);
 
             teamCityClient.ConnectWithAccessToken(teamCityToken);

--- a/source/Scrapers/TeamCityBuildScraper.cs
+++ b/source/Scrapers/TeamCityBuildScraper.cs
@@ -32,7 +32,7 @@ namespace TeamCityBuildStatsScraper.Scrapers
 
             var teamCityToken = configuration.GetValue<string>("TEAMCITY_TOKEN");
             var teamCityUrl = configuration.GetValue<string>("BUILD_SERVER_URL");
-            bool useSSL = configuration.GetValue<bool>("USE_SSL");
+            var useSSL = configuration.GetValue<bool>("USE_SSL");
             var teamCityClient = new TeamCityClient(teamCityUrl, useSSL);
 
             teamCityClient.ConnectWithAccessToken(teamCityToken);

--- a/source/Scrapers/TeamCityBuildScraper.cs
+++ b/source/Scrapers/TeamCityBuildScraper.cs
@@ -32,7 +32,8 @@ namespace TeamCityBuildStatsScraper.Scrapers
 
             var teamCityToken = configuration.GetValue<string>("TEAMCITY_TOKEN");
             var teamCityUrl = configuration.GetValue<string>("BUILD_SERVER_URL");
-            var teamCityClient = new TeamCityClient(teamCityUrl, true);
+            var useSSL = configuration.GetValue<bool>("USE_SSL");
+            var teamCityClient = new TeamCityClient(teamCityUrl, useSSL);
 
             teamCityClient.ConnectWithAccessToken(teamCityToken);
 

--- a/source/Scrapers/TeamCityMutedTestsScraper.cs
+++ b/source/Scrapers/TeamCityMutedTestsScraper.cs
@@ -33,7 +33,7 @@ class TeamCityMutedTestsScraper : BackgroundService
 
         var teamCityToken = configuration.GetValue<string>("TEAMCITY_TOKEN");
         var teamCityUrl = configuration.GetValue<string>("BUILD_SERVER_URL");
-        bool useSSL = configuration.GetValue<bool>("USE_SSL");
+        var useSSL = configuration.GetValue<bool>("USE_SSL");
         var teamCityClient = new TeamCityClient(teamCityUrl, useSSL);
 
         teamCityClient.ConnectWithAccessToken(teamCityToken);

--- a/source/Scrapers/TeamCityMutedTestsScraper.cs
+++ b/source/Scrapers/TeamCityMutedTestsScraper.cs
@@ -33,7 +33,7 @@ class TeamCityMutedTestsScraper : BackgroundService
 
         var teamCityToken = configuration.GetValue<string>("TEAMCITY_TOKEN");
         var teamCityUrl = configuration.GetValue<string>("BUILD_SERVER_URL");
-        var useSSL = configuration.GetValue<bool>("USE_SSL");
+        bool useSSL = configuration.GetValue<bool>("USE_SSL");
         var teamCityClient = new TeamCityClient(teamCityUrl, useSSL);
 
         teamCityClient.ConnectWithAccessToken(teamCityToken);

--- a/source/Scrapers/TeamCityMutedTestsScraper.cs
+++ b/source/Scrapers/TeamCityMutedTestsScraper.cs
@@ -33,10 +33,11 @@ class TeamCityMutedTestsScraper : BackgroundService
 
         var teamCityToken = configuration.GetValue<string>("TEAMCITY_TOKEN");
         var teamCityUrl = configuration.GetValue<string>("BUILD_SERVER_URL");
-        var teamCityClient = new TeamCityClient(teamCityUrl, true);
+        var useSSL = configuration.GetValue<bool>("USE_SSL");
+        var teamCityClient = new TeamCityClient(teamCityUrl, useSSL);
 
         teamCityClient.ConnectWithAccessToken(teamCityToken);
-        
+
         //Unfortunately, we dont seem to be able to use the client for this call,
         //so for now, I'm reaching deep into it's guts to get the field I need. Ick.
         //We should raise a PR (though there hasn't been a release for nearly 12 months)
@@ -45,12 +46,12 @@ class TeamCityMutedTestsScraper : BackgroundService
 
         const string projectId = "OctopusDeploy_OctopusServer";
         var hungBuilds = caller.Get<TestOccurrences>($"/tests?locator=currentlyMuted:true,affectedProject:{projectId}&fields=count");
-        
+
         metricFactory
             .CreateGauge("muted_tests", "Count of muted tests", "projectId")
             .WithLabels(projectId)
             .Set(hungBuilds.Count);
-        
+
         Logger.Debug("Project {ProjectId} has {Count} muted tests", projectId, hungBuilds.Count);
     }
 }

--- a/source/Scrapers/TeamCityQueueLengthScraper.cs
+++ b/source/Scrapers/TeamCityQueueLengthScraper.cs
@@ -32,7 +32,7 @@ namespace TeamCityBuildStatsScraper.Scrapers
 
             var teamCityToken = configuration.GetValue<string>("TEAMCITY_TOKEN");
             var teamCityUrl = configuration.GetValue<string>("BUILD_SERVER_URL");
-            var useSSL = configuration.GetValue<bool>("USE_SSL");
+            bool useSSL = configuration.GetValue<bool>("USE_SSL");
             var teamCityClient = new TeamCityClient(teamCityUrl, useSSL);
 
             teamCityClient.ConnectWithAccessToken(teamCityToken);

--- a/source/Scrapers/TeamCityQueueLengthScraper.cs
+++ b/source/Scrapers/TeamCityQueueLengthScraper.cs
@@ -32,7 +32,7 @@ namespace TeamCityBuildStatsScraper.Scrapers
 
             var teamCityToken = configuration.GetValue<string>("TEAMCITY_TOKEN");
             var teamCityUrl = configuration.GetValue<string>("BUILD_SERVER_URL");
-            bool useSSL = configuration.GetValue<bool>("USE_SSL");
+            var useSSL = configuration.GetValue<bool>("USE_SSL");
             var teamCityClient = new TeamCityClient(teamCityUrl, useSSL);
 
             teamCityClient.ConnectWithAccessToken(teamCityToken);

--- a/source/Scrapers/TeamCityQueueLengthScraper.cs
+++ b/source/Scrapers/TeamCityQueueLengthScraper.cs
@@ -32,7 +32,8 @@ namespace TeamCityBuildStatsScraper.Scrapers
 
             var teamCityToken = configuration.GetValue<string>("TEAMCITY_TOKEN");
             var teamCityUrl = configuration.GetValue<string>("BUILD_SERVER_URL");
-            var teamCityClient = new TeamCityClient(teamCityUrl, true);
+            var useSSL = configuration.GetValue<bool>("USE_SSL");
+            var teamCityClient = new TeamCityClient(teamCityUrl, useSSL);
 
             teamCityClient.ConnectWithAccessToken(teamCityToken);
 

--- a/source/Scrapers/TeamCityQueueWaitScraper.cs
+++ b/source/Scrapers/TeamCityQueueWaitScraper.cs
@@ -32,7 +32,7 @@ namespace TeamCityBuildStatsScraper.Scrapers
 
             var teamCityToken = configuration.GetValue<string>("TEAMCITY_TOKEN");
             var teamCityUrl = configuration.GetValue<string>("BUILD_SERVER_URL");
-            var useSSL = configuration.GetValue<bool>("USE_SSL");
+            bool useSSL = configuration.GetValue<bool>("USE_SSL");
             var teamCityClient = new TeamCityClient(teamCityUrl, useSSL);
 
             teamCityClient.ConnectWithAccessToken(teamCityToken);

--- a/source/Scrapers/TeamCityQueueWaitScraper.cs
+++ b/source/Scrapers/TeamCityQueueWaitScraper.cs
@@ -32,7 +32,7 @@ namespace TeamCityBuildStatsScraper.Scrapers
 
             var teamCityToken = configuration.GetValue<string>("TEAMCITY_TOKEN");
             var teamCityUrl = configuration.GetValue<string>("BUILD_SERVER_URL");
-            bool useSSL = configuration.GetValue<bool>("USE_SSL");
+            var useSSL = configuration.GetValue<bool>("USE_SSL");
             var teamCityClient = new TeamCityClient(teamCityUrl, useSSL);
 
             teamCityClient.ConnectWithAccessToken(teamCityToken);


### PR DESCRIPTION
[sc-94055]

The TeamCityClient object has a parameter on whether to use SSL or not

We currently hard code this to use SSL. 

This PR provides a way to configure whether to use SSL via Environment Variables