### PR TITLE
Trigger renovate-approve-pr.yaml on the labeled event too

### DIFF
--- a/.github/workflows/renovate-approve-pr.yaml
+++ b/.github/workflows/renovate-approve-pr.yaml
@@ -2,6 +2,11 @@ name: "Approve and auto-merge Renovate Pull Requests with automerge label"
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
     branches:
       - main
 


### PR DESCRIPTION
## Summary
`on: pull_request` with no `types:` key defaults to `[opened, synchronize, reopened]` -- it excludes `labeled`. Renovate creates a PR, then adds labels (`autoapprove`, `dependencies`, etc.) as a separate follow-up call. If the `opened` webhook fires before the label-adding call lands, the autoapprove-label check sees no labels, evaluates false, and skips -- permanently, since nothing retriggers the workflow afterward.

This is a race condition that can hit any repo running this automerge pattern -- confirmed on OctopusDeploy/OctopusServerBuildHealthMonitor#344.

## Changes
- Added `labeled` (alongside the existing defaults) to `on: pull_request: types:`, so a later label-add event re-evaluates the condition with the label actually present.

Part of the team-builds Dependabot -> Renovate migration follow-up: [DPT-3088](https://linear.app/octopus/issue/DPT-3088/fix-missing-labeled-event-type-in-renovate-approve-pryaml-race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)